### PR TITLE
Adding requirements file, updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 - **Python 2.7 +**
 - **Requests** 
 - **Beautiful Soup** 
-- **textwrap** 
+- **PyYAML**
+
+To install the module dependencies before running the application, simply navigate into the project folder and run `pip install -r requirements.txt`.
 
 #### I recommend installing Python Anaconda so that all useful libraries are available at one go.
 # Working

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+beautifulsoup4==4.6.0
+bs4==0.0.1
+certifi==2017.7.27.1
+chardet==3.0.4
+idna==2.6
+PyYAML==3.12
+requests==2.18.4
+urllib3==1.22


### PR DESCRIPTION
Changes:

1. Removed textwrap, as it's in the standard library for Python 2.7+.
2. Ran `Main.py` multiple times, and noticed the missing module errors that were produced. Installed those modules and then created the `requirements.txt` file using `pip freeze`.
3. Added PyYAML that was missing from the README file and added instructions on how to easily install the module dependencies.

After installing the dependencies, the tool started successfully.