### PR TITLE
Migrate from News API v1 to v2

### DIFF
--- a/News/NewsPulling.py
+++ b/News/NewsPulling.py
@@ -19,7 +19,7 @@ class NewsPulling(object):
         Configuration = ConfigurationReader()
         self.__APIKey=Configuration.GetAPIKEY()
         self.__Limit=Configuration.GetLimit()
-        url='https://newsapi.org/v1/articles?source='+self.Source+'&sortBy=top&apiKey='+self.__APIKey
+        url='https://newsapi.org/v2/top-headlines?sources='+self.Source+'&sortBy=top&apiKey='+self.__APIKey
         try:
             req=requests.get(url)
             if(req.status_code==200):


### PR DESCRIPTION
I followed the [News API guide](https://newsapi.org/docs/v2-migration) for migrating from v1 to v2. After changing the API URL, I tested on the CLI to ensure the news puller still functions the same way as before.

This resolves the open issue https://github.com/Griffintaur/News-At-Command-Line/issues/24. Based on the docs, this will also open up the ability to onboard more sources that are only supported by v2.
